### PR TITLE
Fixed README example error

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ xhr.open('GET', '/path/to/database.sqlite', true);
 xhr.responseType = 'arraybuffer';
 
 xhr.onload = e => {
-  var uInt8Array = new Uint8Array(this.response);
+  var uInt8Array = new Uint8Array(xhr.response);
   var db = new SQL.Database(uInt8Array);
   var contents = db.exec("SELECT * FROM my_table");
   // contents is now [{columns:['col1','col2',...], values:[[first row], [second row], ...]}]


### PR DESCRIPTION
The original code is not works. `this` points to a global variable (window or global)
ref:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#No_separate_this

